### PR TITLE
fix: provider has moved warning

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     opentelekomcloud = {
-      source = "terraform-providers/opentelekomcloud"
+      source  = "opentelekomcloud/opentelekomcloud"
+      version = "1.20.2"
     }
     template = {
       source = "hashicorp/template"


### PR DESCRIPTION
Hey,

Thanks for providing this repository. During my tests, I stumbled across these warnings.

Thill will fix an appearing warning during `terraform init`

```
Warning: Additional provider information from registry

The remote registry returned warnings for
registry.terraform.io/terraform-providers/opentelekomcloud:
- For users on Terraform 0.13 or greater, this provider has moved to
opentelekomcloud/opentelekomcloud. Please update your source in
required_providers.
```

I also pinned the provider version.